### PR TITLE
`bazel run` and `cargo run` are incompatible

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-mod app;
+// mod app;
 
-use app::app::app;
+// use app::app::app;
+use app::app;
 use axum::extract::WebSocketUpgrade;
 use axum::response::Html;
 use axum::routing::get;


### PR DESCRIPTION
`rules_rust` appears to be linking all files dynamically, but that isn't compatible with the `mod` keyword that's used in cargo projects.

## Before this Change: `cargo run` works, `bazel run` does not

```sh
$ bazel run //src
INFO: Analyzed target //src:src (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /Users/davidmcnamee/dev/rust_app/src/BUILD.bazel:3:12: Compiling Rust bin src (1 files) failed: (Exit 1): process_wrapper failed: error executing command (from target //src:src) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file ... (remaining 243 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0583]: file not found for module `app`
 --> src/main.rs:1:1
  |
1 | mod app;
  | ^^^^^^^^
  |
  = help: to create the module `app`, create file "src/app.rs" or "src/app/mod.rs"

error[E0659]: `app` is ambiguous
 --> src/main.rs:3:5
  |
3 | use app::app::app;
  |     ^^^ ambiguous name
  |
  = note: ambiguous because of multiple potential import sources
  = note: `app` could refer to a crate passed with `--extern`
  = help: use `::app` to refer to this crate unambiguously
note: `app` could also refer to the module defined here
 --> src/main.rs:1:1
  |
1 | mod app;
  | ^^^^^^^^
  = help: use `crate::app` to refer to this module unambiguously

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0583, E0659.
For more information about an error, try `rustc --explain E0583`.
Target //src:src failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.803s, Critical Path: 0.56s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
ERROR: Build failed. Not running target
```

```sh
$ cargo run
   Compiling rust_app v0.1.0 (/Users/davidmcnamee/dev/rust_app)
    Finished dev [unoptimized + debuginfo] target(s) in 2.49s
     Running `target/debug/rust_app`
Listening on http://127.0.0.1:3030
```

## After this Change: `bazel run` works, `cargo run` does not

```sh
$ bazel run //src
INFO: Analyzed target //src:src (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src:src up-to-date:
  bazel-bin/src/src
INFO: Elapsed time: 0.243s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/src/src
Listening on http://127.0.0.1:3030
```

```sh
$ cargo run
   Compiling rust_app v0.1.0 (/Users/davidmcnamee/dev/rust_app)
error[E0432]: unresolved import `app`
 --> src/main.rs:4:5
  |
4 | use app::app;
  |     ^^^ use of undeclared crate or module `app`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `rust_app` due to previous error
```
